### PR TITLE
Fix typo in FrameLayout debug warning comment

### DIFF
--- a/FrameLayoutKit/Classes/FrameLayout.swift
+++ b/FrameLayoutKit/Classes/FrameLayout.swift
@@ -28,7 +28,7 @@ public enum NKContentHorizontalAlignment {
 FrameLayout is the fundamental component of the kit. This class will automatically adjust the size and position of the view assigned to it based on the size and position of the frameLayout itself, and the specified alignment value.
 */
 open class FrameLayout: UIView {
-	/// Show warnings on debug console when adding a UIControl without `isUserInteractionEnabled` turned on, which will make that control untouchabe
+       /// Show warnings on debug console when adding a UIControl without `isUserInteractionEnabled` turned on, which will make that control untouchable
 	public static var showDebugWarnings = false
 	
 	/// Target view that handled by this frameLayout


### PR DESCRIPTION
## Summary
- correct a typo in `FrameLayout.swift`

## Testing
- `swift build` *(fails: no such module 'UIKit')*

------
https://chatgpt.com/codex/tasks/task_e_684bbdcb8748832eb719691121bf3ff4